### PR TITLE
get_perf_detection - timestamp argument

### DIFF
--- a/utils/premiers_resultats_utils.py
+++ b/utils/premiers_resultats_utils.py
@@ -770,12 +770,14 @@ def plot_detection_timeline(df: pd.DataFrame):
 
 
 def _map_datetimes_to_vector(df: pd.DataFrame, timestamps: [int]):
-    """Maps datetime ranges to a binary vector based on overlap with timestamp intervals.
+    """
+    Maps datetime ranges to a binary vector based on overlap with timestamp intervals.
 
     Parameters
     ----------
     df: pandas DataFrame
         APLOSE dataframe with detections
+
     timestamps: list of int
         unix timestamps
 
@@ -807,17 +809,24 @@ def _map_datetimes_to_vector(df: pd.DataFrame, timestamps: [int]):
 
 def get_detection_perf(
     df: pd.DataFrame,
+    timestamps: list[pd.Timestamp] = None,
     start: pd.Timestamp = None,
     stop: pd.Timestamp = None,
 ):
-    """Computes the detection performances of a reference annotator in comparison with a second annotator/detector
+    """
+    Computes the detection performances of a reference annotator in comparison with a second annotator/detector
 
     Parameters
     ----------
     df: pd.DataFrame
         APLOSE formatted detection/annotation DataFrame
+
+    timestamps: list[pd.Timestamp]
+        list of datetimes to base the computation on
+
     start: pd.Timestamp
         begin datetime, optional
+
     stop: pd.Timestamp
         end datetime, optional
     """
@@ -829,10 +838,14 @@ def get_detection_perf(
     if len(annotators) < 2:
         raise ValueError("At least 2 annotators needed")
 
-    timestamps = [
-        ts.timestamp()
-        for ts in pd.date_range(start=datetime_begin, end=datetime_end, freq=df_freq)
-    ]
+    if not timestamps:
+        timestamps = [
+            ts.timestamp()
+            for ts in pd.date_range(start=datetime_begin, end=datetime_end, freq=df_freq)
+        ]
+    else:
+        timestamps = [ts.timestamp() for ts in timestamps]
+
     if start and stop:
         if start > stop:
             raise ValueError(


### PR DESCRIPTION
Issue : `get_detection_perf` did not take into account non-continuous dataset

The present PR fixes this issue by providing a `timestamps` argument which the computation is based

Example of use:
```
from pathlib import Path
from pandas import read_csv

from premiers_resultats_utils import (
    load_parameters_from_yaml,
    get_detection_perf,
)

def perf():
    yaml_file = Path(r"path\to\yaml")
    df_detections, _, _, _, _, _, _, _ = (load_parameters_from_yaml(file=yaml_file))
    timestamp_path = Path(r"path\to\timestamp")
    timestamps = read_csv(timestamp_path, parse_dates=["timestamp"])["timestamp"].to_list()
    get_detection_perf(df=df_detections, timestamps=timestamps)

if __name__ == "__main__":
    perf()
```